### PR TITLE
Add simulator option in evaluator

### DIFF
--- a/multimodalfitting/models/model.py
+++ b/multimodalfitting/models/model.py
@@ -295,6 +295,22 @@ def define_parameters(cell_model_folder, parameter_file=None, release=False, v_i
                 % param_config
             )
 
+        # add v_init if specified as an argument, but not in the parameters
+        has_v_init = False
+        for param in parameters:
+            if param.name == "v_init":
+                has_v_init = True
+        if not has_v_init and v_init is not None:
+            parameters.append(
+                ephys.parameters.NrnGlobalParameter(
+                    name="v_init",
+                    param_name="v_init",
+                    frozen=True,
+                    bounds=None,
+                    value=v_init,
+                )
+            )
+
     return parameters
 
 
@@ -353,6 +369,10 @@ def create_ground_truth_model(model_name, cell_model_folder, release=False, v_in
         by default False
     v_init : float, optional
         Initial membrane potential value, by default None
+    model_type : str, optional
+        * "neuron": instantiate a CellModel
+        * "LFPy": instantiate an LFPyCellModel
+        by default "LFPy"
     **morph_kwargs: kwargs for morphology modifiers
 
     Returns
@@ -360,6 +380,7 @@ def create_ground_truth_model(model_name, cell_model_folder, release=False, v_in
     bluepyopt.ephys.models.LFPyCellModel or bluepyopt.ephys.models.CellModel
         The BluePyOpt model object
     """
+    assert model_type.lower() in ["lfpy", "neuron"]
 
     if model_name == "hay":
         morph_modifiers = None
@@ -393,7 +414,7 @@ def create_ground_truth_model(model_name, cell_model_folder, release=False, v_in
 
     cell_model_folder = Path(cell_model_folder)
 
-    if model_type == "LFPy":
+    if model_type.lower() == "LFPy":
         model_class = ephys.models.LFPyCellModel
         model_kwargs = {'v_init': v_init}
     else:
@@ -443,6 +464,8 @@ def create_experimental_model(morphology_file, cell_model_folder, release=False,
         The BluePyOpt model object
     """
     morph_modifiers = [fix_morphology_exp]
+    
+    assert model_type.lower() in ["lfpy", "neuron"]
 
     if abd:
         morph_kwargs.update({"abd": True})
@@ -475,7 +498,7 @@ def create_experimental_model(morphology_file, cell_model_folder, release=False,
         morph_modifiers_kwargs=morph_kwargs
     )
 
-    if model_type == "LFPy":
+    if model_type.lower == "lfpy":
         model_class = ephys.models.LFPyCellModel
         model_kwargs = {'v_init': v_init}
     else:

--- a/scripts/ipyparallel.sbatch
+++ b/scripts/ipyparallel.sbatch
@@ -32,4 +32,5 @@ sleep 20
                                                                 --model=${OPT_MODEL}                     \
                                                                 --data-folder=${DATA_FOLDER}             \
                                                                 --opt-folder=${OPT_FOLDER}               \
-                                                                --extra-strategy=${OPT_EXTRA_STRATEGY}
+                                                                --extra-strategy=${OPT_EXTRA_STRATEGY}   \
+                                                                --sim=${SIM}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,6 @@
 export OPT_MODEL='hay'  # hay | hay_ais | experimental
 
+export SIM='lfpy' # lfpy | neuron
 # Define model and experimental folders here. They should contain:
 # features_BPO.json, protocols_BPO.json, probe_BPO.json,
 exp_folder='../data/experimental/210301_3113_cell1/efeatures'


### PR DESCRIPTION
The simulator option (`lfpy` or `neuron`) allows to run optimizations with either of the two frameworks

@DrTaDa can you test this? You can just set the `--sim neuron` in the run optimization script
